### PR TITLE
Add dateutils ad dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 confygure >= 0.1.0
 prometheus-client
+python-dateutil
 requests


### PR DESCRIPTION
This patch adds `dateutils` as dependency. It was missing from the `requirements.txt`.