### PR TITLE
Fix sorting of events

### DIFF
--- a/occameracontrol/agent.py
+++ b/occameracontrol/agent.py
@@ -86,7 +86,7 @@ class Agent:
             events.append(event)
 
         # Make sure events are sorted
-        return sorted(events, key=lambda e: e.start, reverse=True)
+        return sorted(events, key=lambda e: e.start, reverse=False)
 
     def update_calendar(self):
         '''Get a calendar update fro Opencast


### PR DESCRIPTION
This patch fixes the sorting order of events so that the next event is actually the next event and not the last scheduled event.