### PR TITLE
Install binary in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
+FROM python:3.12-slim as build
+COPY . /occameracontrol
+
 FROM python:3.12-slim
 EXPOSE 8000
-
-COPY . /occameracontrol
-WORKDIR /occameracontrol
-
-RUN pip install --no-cache-dir -r /occameracontrol/requirements.txt
+RUN --mount=type=bind,from=build,source=/occameracontrol,target=/occameracontrol \
+    --mount=type=tmpfs,destination=/tmp \
+    cp -r /occameracontrol /tmp \
+    && pip install --no-cache-dir /tmp/occameracontrol \
+    && cp /occameracontrol/camera-control.yml /etc/camera-control.yml
 
 USER nobody
-ENTRYPOINT [ "python",  "-m", "occameracontrol"]
+ENTRYPOINT [ "opencast-camera-control" ]

--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ services:
     ports:
       - '8000:8000'
     volumes:
-      - './your_config.yml:/occameracontrol/config.yml'
+      - './your_config.yml:/etc/camera-control.yml'
 ```


### PR DESCRIPTION
Instead of copying the source code and executing the package, this patch only installs the binary in the container, discarding additional source files.

This will not make much of a difference but should be slightly faster and result in slightly smaller containers.

This also now uses the arguably nicer location of
`/etc/camera-control.yml` for the default configuration file. This means that we will have the same configuration location for all installation types.