### PR TITLE
Support Sony SRG-300SE

### DIFF
--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -83,7 +83,7 @@ class Camera:
 
         elif self.type == CameraType.sony:
             url = f'{self.url}/command/presetposition.cgi'
-            params = {'PresetCall': preset}
+            params = {'PresetCall': f'{preset},24'}
             headers = {'referer': f'{self.url}/'}
             auth = HTTPDigestAuth(self.user, self.password) \
                 if self.user and self.password else None


### PR DESCRIPTION
This patch slightly modifies the preset command sent to Sony cameras so that it will work not only with SRG-X120 models, but also with SRG-300SE.