### PR TITLE
Automatically build RPMs for releases

### DIFF
--- a/.github/rpm/opencast-camera-control.service
+++ b/.github/rpm/opencast-camera-control.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Opencast Camera Control
+Documentation=https://github.com/virtUOS/opencast-camera-control
+Wants=network.target
+
+[Service]
+Type=simple
+User=opencastcamera
+ExecStart=/usr/bin/opencast-camera-control
+Restart=always

--- a/.github/rpm/opencast-camera-control.spec
+++ b/.github/rpm/opencast-camera-control.spec
@@ -68,7 +68,7 @@ if [ ! $(getent group %{gid}) ]; then
 	groupadd -r %{gid} > /dev/null 2>&1 || :
 fi
 if [ ! $(getent passwd %{uid}) ]; then
-	useradd -M -r -d /srv/opencast -g %{gid} %{uid} > /dev/null 2>&1 || :
+	useradd -M -r -g %{gid} %{uid} > /dev/null 2>&1 || :
 fi
 
 

--- a/.github/rpm/opencast-camera-control.spec
+++ b/.github/rpm/opencast-camera-control.spec
@@ -1,0 +1,98 @@
+# Created by pyp2rpm-3.3.8
+%global pypi_name opencast-camera-control
+%global pypi_version %{_camera_control_version}
+
+%define uid   opencastcamera
+%define gid   opencastcamera
+
+Name:           %{pypi_name}
+Version:        %{pypi_version}
+Release:        1%{?dist}
+Summary:        Automated Camera Control for Opencast
+
+License:        GPLv3+
+
+URL:            None
+Source0:        https://github.com/virtUOS/%{name}/archive/refs/tags/%{version}.tar.gz
+Source1:        https://raw.githubusercontent.com/virtUOS/%{name}/%{version}/camera-control.yml
+Source2:        opencast-camera-control.service
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(setuptools)
+
+Requires:       python3dist(confygure) >= 0.1
+Requires:       python3dist(prometheus-client)
+Requires:       python3dist(python-dateutil)
+Requires:       python3dist(requests)
+Requires:       python3dist(setuptools)
+
+BuildRequires:     systemd
+Requires(post):    systemd
+Requires(preun):   systemd
+Requires(postun):  systemd
+
+%description
+Control PTZ camera to move to certain presets when
+starting a scheduled recording.
+
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+
+%prep
+%autosetup -n %{pypi_name}-%{pypi_version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+# Patch setup.py
+# This is a workaround for the Python toolchain in EL9 not supporting the new pyproject.toml
+echo 'from setuptools import setup' > setup.py
+echo "setup(name = 'opencast-camera-control', $(grep version pyproject.toml), packages=['occameracontrol']," >> setup.py
+echo "  entry_points={'console_scripts':['opencast-camera-control = occameracontrol.__main__:main' ]})" >> setup.py
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+# Install configuration
+install -m 0644 -p -D %{SOURCE1} %{buildroot}%{_sysconfdir}/camera-control.yml
+
+# Install Systemd unit file
+install -m 0644 -p -D %{SOURCE2} %{buildroot}%{_unitdir}/%{name}.service
+
+
+%pre
+# Create user and group if nonexistent
+if [ ! $(getent group %{gid}) ]; then
+	groupadd -r %{gid} > /dev/null 2>&1 || :
+fi
+if [ ! $(getent passwd %{uid}) ]; then
+	useradd -M -r -d /srv/opencast -g %{gid} %{uid} > /dev/null 2>&1 || :
+fi
+
+
+%post
+%systemd_post %{name}.service
+
+
+%preun
+%systemd_preun %{name}.service
+
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/opencast-camera-control
+%{_unitdir}/%{name}.service
+%{python3_sitelib}/occameracontrol
+%{python3_sitelib}/opencast_camera_control-%{pypi_version}-py%{python3_version}.egg-info
+%config(noreplace) %{_sysconfdir}/camera-control.yml
+
+%changelog
+* Tue Mar 26 2024 Lars Kiesow <lkiesow@uos.de> - 0.1.0-1
+- Initial package.

--- a/.github/rpm/python-confygure.spec
+++ b/.github/rpm/python-confygure.spec
@@ -1,0 +1,53 @@
+# Created by pyp2rpm-3.3.8
+%global pypi_name confygure
+%global pypi_version 0.1.0
+
+Name:           python-%{pypi_name}
+Version:        %{pypi_version}
+Release:        1%{?dist}
+Summary:        A simple YAML based configuration library for Python
+
+License:        MIT
+URL:            None
+Source0:        %{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(setuptools)
+
+%description
+A simple YAML based configuration library for Python
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3dist(pyyaml)
+%description -n python3-%{pypi_name}
+A simple YAML based configuration library for Python
+
+
+%prep
+%autosetup -n %{pypi_name}-%{pypi_version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+# Patch setup.py
+# This is a workaround for the Python toolchain in EL9 not supporting the new pyproject.toml
+echo 'from setuptools import setup' > setup.py
+echo "setup(name = 'confygure', $(grep version pyproject.toml), packages=['confygure'])" >> setup.py
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files -n python3-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/%{pypi_name}-%{pypi_version}-py%{python3_version}.egg-info
+
+%changelog
+* Tue Mar 26 2024 Lars Kiesow <lkiesow@uos.de> - 0.1.0-1
+- Initial package.

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -1,0 +1,104 @@
+name: Build RPMs
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        osversion:
+          - '9'
+    name: build (el${{ matrix.osversion }})
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream${{ matrix.osversion }}
+    steps:
+      - name: install tools
+        run: >
+          dnf install -y
+          createrepo
+          'dnf-command(builddep)'
+          git
+          gnupg
+          rpmdevtools
+          rpm-sign
+
+      - name: clone repository
+        uses: actions/checkout@v4
+
+      - name: prepare git
+        run: |
+          git config --global user.name "RPM Builder"
+          git config --global user.email "virtuos@uni-osnabrueck.de"
+
+      - name: prepare gpg
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+        run: |
+          echo "${GPG_KEY}" | gpg --import
+          echo '%_gpg_name D1D3C4C53BB1516C13C86647F3AC651D45D407D3' > ~/.rpmmacros
+
+      - name: get version
+        run: >
+          sed -n 's/^version *=[^0-9]*\(.*\). */%_camera_control_version \1/p'
+          pyproject.toml >> ~/.rpmmacros
+
+      - name: prepare build tree
+        run: |
+          rpmdev-setuptree
+
+      - name: copy service file
+        run: |
+          cp .github/rpm/opencast-camera-control.service ~/rpmbuild/SOURCES/
+
+      - name: install build dependencies
+        working-directory: .github/rpm/
+        run: |
+          dnf builddep -y opencast-camera-control.spec
+
+      - name: download sources
+        working-directory: .github/rpm/
+        run: |
+          spectool -gR opencast-camera-control.spec
+
+      - name: build rpm
+        working-directory: .github/rpm/
+        run: |
+          rpmbuild -ba opencast-camera-control.spec
+
+      - name: switch to repository branch
+        run: |
+          chown root:root .
+          git fetch
+          git checkout rpm-el${{ matrix.osversion }}
+
+      - name: sign rpms
+        run: |
+          rpmsign --addsign ~/rpmbuild/RPMS/noarch/*.rpm
+
+      - name: copy rpms to repository
+        run: |
+          cp -v ~/rpmbuild/RPMS/noarch/*.rpm .
+
+      - name: add new rpms
+        run: |
+          git add ./*.rpm
+
+      - name: update repository metadata
+        run: |
+          createrepo --update .
+          git add ./repodata/
+
+      - name: commit changes
+        run: |
+          git status
+          RPM="$(ls -1 ~/rpmbuild/RPMS/noarch/ | tail -n1)"
+          git diff --staged --quiet || git commit -m "Build ${RPM} $(date)"
+
+      - name: push updates
+        run: |
+          git remote -v
+          git push

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ agent_calendar_update_time{agent="test_agent"} 1.707571943100096e+09
 camera_position{camera="http://camera-2-panasonic.example.com"} 10.0
 ```
 
+
+## RPM Repository
+
+On RHEL 9 like distributions (CentOS Stream, Rocky, Alma, …) you can use the RPM repository to install Opencast Camera Control.
+Install the repository by adding a file `/etc/yum.repos.d/opencast-camera-control.repo`:
+
+```
+[opencast-camera-control]
+name = Opencast camera control el$releasever repository
+baseurl  = https://raw.githubusercontent.com/virtUOS/opencast-camera-control/rpm-el$releasever/
+enabled  = 1
+gpgcheck = 1
+gpgkey = https://raw.githubusercontent.com/virtUOS/opencast-camera-control/rpm-el$releasever/opencast-camera-control.key
+```
+
+Then activate the EPEL repository and install `opencast-camera-control`:
+
+```
+dnf install epel-release
+dnf install opencast-camera-control
+```
+
+The RPM packages provide a Systemd unit to run the tool as service:
+
+```
+systemctl start opencast-camera-control.service
+systemctl enable opencast-camera-control.service
+```
+
+
 ## Docker
 
 We also provide a container image.


### PR DESCRIPTION
This patch automatically builds RPM packages for tagged releases and pushes them to a repository. The repository lives in the branch `rpm-el9` and is meant for use with RHEL 9 like distributions.

This closes #47