### PR TITLE
Info as default log level

### DIFF
--- a/camera-control.yml
+++ b/camera-control.yml
@@ -69,4 +69,4 @@ metrics:
 # Configure the log level
 # Available levels are: debug, info, warning, error, critical)
 # Default: info
-loglevel: debug
+loglevel: info


### PR DESCRIPTION
This patch drops the default log level from `debug` to `info`. Debug logs are usually unnecessary.