### PR TITLE
Add yamllint for config

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,19 @@
+---
+
+name: yamllint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install yamllint
+        run: pip3 install yamllint
+
+      - run: yamllint camera-control.yml

--- a/camera-control.yml
+++ b/camera-control.yml
@@ -1,3 +1,5 @@
+---
+
 opencast:
   # Opencast server to talk to
   server: https://develop.opencast.org
@@ -47,8 +49,8 @@ camera:
 
 metrics:
   # Enable metrics to start a web server and provide OpenMetrics data
-  # Default: False
-  enabled: True
+  # Default: false
+  enabled: true
 
   # The TCP port to listen to
   # Default: 8000


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to run `yamllint` on the configuration file. It also fixes an incorrectly formatted boolean value which would have been detected by `yamllint`.