### PR TITLE
Add install target to systemd unit

### DIFF
--- a/.github/rpm/opencast-camera-control.service
+++ b/.github/rpm/opencast-camera-control.service
@@ -8,3 +8,6 @@ Type=simple
 User=opencastcamera
 ExecStart=/usr/bin/opencast-camera-control
 Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This patch adds the missing installation target to the Systemd unit file to ensure the system is actually installed when needed.