### PR TITLE
Initial Position after Restart

### DIFF
--- a/occameracontrol/agent.py
+++ b/occameracontrol/agent.py
@@ -60,6 +60,7 @@ class Agent:
     '''
     agent_id: str
     events: list[Event] = []
+    calendar_initialized: bool = False
 
     def __init__(self, agent_id: str):
         self.agent_id = agent_id
@@ -108,6 +109,7 @@ class Agent:
 
         self.events = self.parse_calendar(calendar)
         register_calendar_update(self.agent_id)
+        self.calendar_initialized = True
 
     def active_events(self):
         '''Return a list of active events

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -104,9 +104,14 @@ class Camera:
         necessary.
         '''
         agent_id = self.agent.agent_id
+        level = logging.DEBUG if int(time.time()) % 60 else logging.INFO
+
+        while not self.agent.calendar_initialized:
+            logger.log(level, '[%s] Calendar not yet initialized…', agent_id)
+            time.sleep(1)
+
         event = self.agent.next_event()
 
-        level = logging.DEBUG if int(time.time()) % 60 else logging.INFO
         if event.future():
             logger.log(level, '[%s] Next event `%s` starts in %i seconds',
                        agent_id, event.title[:40], event.start - time.time())


### PR DESCRIPTION
This patch ensures that the calendar data is updated at least once before repositioning the camera. This ensures that active recordings are no longer interrupted by moving the camera to the neutral position on (re-)start.

This fixes #63