### PR TITLE
Explicitly specify package for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ Repository = 'https://github.com/virtUOS/opencast-camera-control'
 
 [project.scripts]
 opencast-camera-control = 'occameracontrol.__main__:main'
+
+[tool.setuptools]
+packages = ['occameracontrol']


### PR DESCRIPTION
This patch explicitly specifies the package for setuptools so that additional folders in the current workspace are not picked up by accident.

For example, here I still had a folder `rpm` in my workspace while running `setup.py`:

```
✦ ❯ python setup.py sdist
error: Multiple top-level packages discovered in a flat-layout: ['rpm', 'occameracontrol'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
```