### PR TITLE
No stack traces for read timeouts

### DIFF
--- a/occameracontrol/metrics.py
+++ b/occameracontrol/metrics.py
@@ -53,7 +53,8 @@ class RequestErrorHandler():
 
     err_msg_only = (
             requests.exceptions.ConnectionError,
-            requests.exceptions.HTTPError)
+            requests.exceptions.HTTPError,
+            requests.exceptions.ReadTimeout)
 
     def __init__(self, resource, message):
         '''Create a RequestErrorHandler instance.


### PR DESCRIPTION
We don't need full stack traces for read timeouts. This patch shortens the error logs to:

```
May 06 12:04:42 vm350.rz.uni-osnabrueck.de opencast-camera-control[523905]: ERROR:occameracontrol.metrics:Failed to communicate with camera 'arec-15-421' @ 'http://camera1-15-421.example.com': HTTPConnectionPool(host='camera1-15-421.example.com', port=80): Read timed out. (read timeout=5)
```

This fixes #84