### PR TITLE
Retrieving Camera status before initiating preset move

### DIFF
--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -129,17 +129,14 @@ class Camera:
                                     timeout=5)
             response.raise_for_status()
             values = response.content.decode().split("&")
-            state = -1
+            state = False
             for v in values:
                 if "Power" in v:
                     if v.removeprefix("Power=")[1] == 'on':
-                        state = True
+                        return True
                     else:
-                        state = False
-            return state
-
-        # Else case
-        return -1
+                        return False
+        return False
 
     def activate_camera(self, on=True):
         """Activate the camera or put it into standby mode.

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -146,7 +146,6 @@ class Camera:
         if self.type == CameraType.panasonic:
             url = f'{self.url}/cgi-bin/aw_ptz'
             # If the camera is in Standby, turn it on
-            # (Does this make sense here?)
             command = '#On' if not turn_on else '#Of'
             params = {'cmd': command, 'res': 1}
             auth = (self.user, self.password) \

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -75,7 +75,7 @@ class Camera:
         '''
         return f"'{self.agent.agent_id}' @ '{self.url}'"
 
-    def is_standby(self) -> bool:
+    def is_standby(self):
         """Retrieve whether or not the camera is in Standby.
         For Panasonic camera AW-UE70:
             0   if      Standby
@@ -113,8 +113,7 @@ class Camera:
                     timeout=5)
                 response.raise_for_status()
                 state = int(response.content.decode())
-                state = bool(state)
-            return state
+            return bool(state)
 
         if self.type == CameraType.sony:
             url = f'{self.url}/command/inquiry.cgi'

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -79,22 +79,24 @@ class Camera:
         """Retrieve whether or not the camera is in Standby.
         For Panasonic camera AW-UE70:
             0   if      Standby
-            1   if      On  
+            1   if      On
             3   if      Transferring from Standby to On
-            TODO: Which panasonic models do we have? Maybe there is a difference for other models?
-            --> Works for the two models that we have  
-            
+            TODO:
+            - Which panasonic models do we have?
+            - Maybe there is a difference for other models?
+            --> Works for the two models that we have
+
         For Sony camera:
             0   if      Standby
-            1   if      On  
+            1   if      On
 
-            -1  if      Something went wrong    
+            -1  if      Something went wrong
         """
 
         if self.type == CameraType.panasonic:
             url = f'{self.url}/cgi-bin/aw_ptz'
             command = "#O"
-            params = {'cmd':command, 'res':1}
+            params = {'cmd': command, 'res': 1}
             auth = (self.user, self.password) \
                 if self.user and self.password else None
             logger.debug('GET %s with params: %s', url, params)
@@ -104,11 +106,15 @@ class Camera:
             while state == 3:
                 # Escape the transition from standby to on
                 time.sleep(3)
-                response = requests.get(url, auth=auth, params=params, timeout=5)
+                response = requests.get(
+                    url,
+                    auth=auth,
+                    params=params,
+                    timeout=5)
                 response.raise_for_status()
                 state = int(response.content.decode())
                 state = bool(state)
-            return(state)
+            return state
 
         if self.type == CameraType.sony:
             url = f'{self.url}/command/inquiry.cgi'
@@ -132,7 +138,7 @@ class Camera:
                     else:
                         state = False
             return state
-        
+
         # Else case
         return -1
 
@@ -142,7 +148,8 @@ class Camera:
         """
         if self.type == CameraType.panasonic:
             url = f'{self.url}/cgi-bin/aw_ptz'
-            # If the camera is in Standby, turn it on (Does this make sense here?)
+            # If the camera is in Standby, turn it on
+            # (Does this make sense here?)
             command = '#On' if not on else '#Of'
             params = {'cmd': command, 'res': 1}
             auth = (self.user, self.password) \

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -75,6 +75,33 @@ class Camera:
         '''
         return f"'{self.agent.agent_id}' @ '{self.url}'"
 
+    def is_standby(self) -> int:
+        """Retrieve whether or not the camera is in Standby.
+        For Panasonic camera AW-UE70:
+            0   if      Standby
+            1   if      On  
+            3   if      Transferring from Standby to On
+            TODO: Which panasonic models do we have? Maybe there is a difference for other models? 
+            
+        For Sony camera:
+        TODO    
+        """
+        
+        if self.type == CameraType.panasonic:
+            url = f'{self.url}/cgi-bin/aw_ptz'
+            command = "#O"
+            params = {'cmd':command, 'res':1}
+            auth = (self.user, self.password) \
+                if self.user and self.password else None
+            logger.debug('GET %s with params: %s', url, params)
+            response = requests.get(url, auth=auth, params=params, timeout=5)
+            response.raise_for_status()
+            state = response.content.decode()
+            return state.removeprefix('p')
+        elif self.type == CameraType.sony:
+            # TODO
+            return -1
+
     def activate_camera(self, on=True):
         """Activate the camera or put it into standby mode.
         :param bool on: camera should be online or standby (default: True)


### PR DESCRIPTION
Added a function `is_on()` that returns the current status of the camera. 

This function is called before the camera should be moved to a preset, in case  the camera is in Standby and has to be turned on before it can record.

This fixes #88.