### PR TITLE
Added flag for switching the camera control status

### DIFF
--- a/camera-control.yml
+++ b/camera-control.yml
@@ -39,7 +39,9 @@ camera_update_frequency: 300
 #     password: password to access the API (optional)
 #     preset_active: Camera preset to move to when recording (default: 1)
 #     preset_inactive: Camera preset to move to when not recording (default: 10)
-#     control: Flag for switching between automatic and manual camera control (default: "automatic")
+#     control: Flag for switching between automatic and manual camera control
+#              (default: "automatic")
+
 camera:
   test-agent:
     - url: http://camera-panasonic.example.com

--- a/camera-control.yml
+++ b/camera-control.yml
@@ -39,6 +39,7 @@ camera_update_frequency: 300
 #     password: password to access the API (optional)
 #     preset_active: Camera preset to move to when recording (default: 1)
 #     preset_inactive: Camera preset to move to when not recording (default: 10)
+#     control: Flag for switching between automatic and manual camera control (default: "automatic")
 camera:
   test-agent:
     - url: http://camera-panasonic.example.com

--- a/occameracontrol/__main__.py
+++ b/occameracontrol/__main__.py
@@ -106,7 +106,8 @@ def main():
     agent_update.start()
 
     for camera in cameras:
-        logger.info('Starting camera control for %s with control status %s', camera, getattr(camera, 'control'))
+        logger.info('Starting camera control for %s with control status %s',
+                    camera, getattr(camera, 'control'))
         control_thread = Thread(target=control_camera, args=(camera,))
         threads.append(control_thread)
         control_thread.start()

--- a/occameracontrol/__main__.py
+++ b/occameracontrol/__main__.py
@@ -26,6 +26,8 @@ from occameracontrol.agent import Agent
 from occameracontrol.camera import Camera
 from occameracontrol.metrics import start_metrics_exporter, RequestErrorHandler
 
+from occameracontrol.camera_control_server import start_camera_control_server
+
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +59,11 @@ def control_camera(camera: Camera):
             f'Failed to communicate with camera {camera}')
     while True:
         with error_handler:
-            camera.update_position()
+            if camera.control == "automatic":
+                camera.update_position()
+            else:
+                camera.activate_camera()
+                camera.check_calendar()
         time.sleep(1)
 
 
@@ -100,13 +106,16 @@ def main():
     agent_update.start()
 
     for camera in cameras:
-        logger.info('Starting camera control for %s', camera)
+        logger.info('Starting camera control for %s with control status %s', camera, getattr(camera, 'control'))
         control_thread = Thread(target=control_camera, args=(camera,))
         threads.append(control_thread)
         control_thread.start()
 
     # Start delivering metrics
     start_metrics_exporter()
+
+    # Start camera control server
+    start_camera_control_server(cameras=cameras)
 
     try:
         for thread in threads:

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -52,6 +52,12 @@ class Camera:
     preset_inactive: int = 10
     last_updated: float = 0.0
     update_frequency: int = 300
+    # Flag for switching between automatic and manual camera control
+    # automatic  = The corresponding camera will be controlled automatically, i.e. the camera position will be adjusted
+    #              according to the agent's state and the values given in preset_active and preset_inactive
+    # manual     = The corresponding camera will be controlled manually. Values in preset_active and preset_inactive will
+    #              be ignored as well as the agent's status
+    control: str = "automatic"
 
     def __init__(self,
                  agent: Agent,
@@ -60,7 +66,8 @@ class Camera:
                  user: Optional[str] = None,
                  password: Optional[str] = None,
                  preset_active: int = 1,
-                 preset_inactive: int = 10):
+                 preset_inactive: int = 10,
+                 control: str = "automatic"):
         self.agent = agent
         self.url = url.rstrip('/')
         self.type = CameraType[type]
@@ -69,6 +76,7 @@ class Camera:
         self.preset_active = preset_active
         self.preset_inactive = preset_inactive
         self.update_frequency = config_t(int, 'camera_update_frequency') or 300
+        self.control = control
 
     def __str__(self) -> str:
         '''Returns a string representation of this camera
@@ -107,6 +115,7 @@ class Camera:
     def move_to_preset(self, preset: int):
         '''Move the PTZ camera to the specified preset position
         '''
+        self.activate_camera()
         register_camera_expectation(self.url, preset)
         if self.type == CameraType.panasonic:
             params = {'cmd': f'#R{preset - 1:02}', 'res': 1}
@@ -141,12 +150,8 @@ class Camera:
         '''
         seconds = int(ts - time.time())  # seconds are enough accuracy
         return str(datetime.timedelta(seconds=seconds))
-
-    def update_position(self):
-        '''Check for currently active events with the camera's capture agent
-        and move the camera to the appropriate (active, inactive) position if
-        necessary.
-        '''
+    
+    def check_calendar(self):
         agent_id = self.agent.agent_id
         level = logging.DEBUG if int(time.time()) % 60 else logging.INFO
 
@@ -155,7 +160,6 @@ class Camera:
             time.sleep(1)
 
         event = self.agent.next_event()
-
         if event.future():
             logger.log(level, '[%s] Next event `%s` starts in %s',
                        agent_id, event.title[:40], self.from_now(event.start))
@@ -165,22 +169,29 @@ class Camera:
         else:
             logger.log(level, '[%s] No planned events', agent_id)
 
+        return event
+
+    def update_position(self):
+        '''Check for currently active events with the camera's capture agent
+        and move the camera to the appropriate (active, inactive) position if
+        necessary.
+        '''
+        agent_id = self.agent.agent_id
+        event = self.check_calendar()
+        
         if event.active():  # active event
             if self.position != self.preset_active:
                 logger.info('[%s] Event `%s` started', agent_id, event.title)
                 logger.info('[%s] Moving to preset %i', agent_id,
                             self.preset_active)
-                self.activate_camera()
                 self.move_to_preset(self.preset_active)
         else:  # No active event
             if self.position != self.preset_inactive:
                 logger.info('[%s] Returning to preset %i', agent_id,
                             self.preset_inactive)
-                self.activate_camera()
                 self.move_to_preset(self.preset_inactive)
 
         if time.time() - self.last_updated >= self.update_frequency:
             logger.info('[%s] Re-sending preset %i to camera', agent_id,
                         self.position)
-            self.activate_camera()
             self.move_to_preset(self.position)

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -53,9 +53,12 @@ class Camera:
     last_updated: float = 0.0
     update_frequency: int = 300
     # Flag for switching between automatic and manual camera control
-    # automatic  = The corresponding camera will be controlled automatically, i.e. the camera position will be adjusted
-    #              according to the agent's state and the values given in preset_active and preset_inactive
-    # manual     = The corresponding camera will be controlled manually. Values in preset_active and preset_inactive will
+    # automatic  = The corresponding camera will be controlled automatically,
+    #              i.e. the camera position will be adjusted
+    #              according to the agent's state and the values given
+    #              in preset_active and preset_inactive
+    # manual     = The corresponding camera will be controlled manually.
+    #              Values in preset_active and preset_inactive will
     #              be ignored as well as the agent's status
     control: str = "automatic"
 
@@ -150,7 +153,7 @@ class Camera:
         '''
         seconds = int(ts - time.time())  # seconds are enough accuracy
         return str(datetime.timedelta(seconds=seconds))
-    
+
     def check_calendar(self):
         agent_id = self.agent.agent_id
         level = logging.DEBUG if int(time.time()) % 60 else logging.INFO
@@ -178,7 +181,6 @@ class Camera:
         '''
         agent_id = self.agent.agent_id
         event = self.check_calendar()
-        
         if event.active():  # active event
             if self.position != self.preset_active:
                 logger.info('[%s] Event `%s` started', agent_id, event.title)

--- a/occameracontrol/camera_control_server.py
+++ b/occameracontrol/camera_control_server.py
@@ -15,15 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from importlib.metadata import requires
 
-from confygure import config_t
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from flask import Flask, Response
 
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+
 
 @app.route('/control/<string:status>/<string:req_camera_url>')
 # @requires_auth
@@ -33,43 +32,59 @@ def activate_camera(status, req_camera_url):
     """
     if status == "manual":
         logger.info('Camera with URL "[%s]" will be controlled manually and ' +
-                            'therefore it\'s position won\'t be updated automatically.', req_camera_url)
+                    'therefore it\'s position won\'t be updated automatically',
+                    req_camera_url)
     elif status == "automatic":
-        logger.info('Camera with URL "[%s]" will switch to automatic controlling. The ' +
-                            'camera\'s position will be adjusted to the corresponding agent\'s status automatically.', req_camera_url)
+        logger.info('Camera with URL "[%s]" will switch to automatic ' +
+                    'controlling. The camera\'s position will be ' +
+                    'adjusted to the corresponding agent\'s status ' +
+                    'automatically.', req_camera_url)
     else:
-        return f"ERROR<br/>Given status '{status}' is invalid. Please use 'manual' or 'automatic' instead."
-
+        return 'ERROR<br/>Given status %s is invalid.', status
 
     # Get rid of http or https prefixes to ensure reliable comparability
-    sanitized_camera_url = str.replace(req_camera_url, 'http://', '').replace('https://', '')
+    sanitized_camera_url = str.replace(req_camera_url, 'http://', '')
+    sanitized_camera_url = str.replace(req_camera_url, 'https://', '')
     cameras = app.config["cameras"]
     for camera in cameras:
-        camera_url = str.replace(getattr(camera, 'url'), 'http://', '').replace('https://', '')
+        camera_url = str.replace(getattr(camera, 'url'), 'http://', '')
+        camera_url = str.replace(getattr(camera, 'url'), 'https://', '')
+
         if sanitized_camera_url == camera_url:
             setattr(camera, 'control', status)
             # Resets the current position of the camera
             setattr(camera, 'position', -1)
-            return f"SUCCESS<br/>Successfully set camera with url '{camera_url}' to control status <b>'{status}'</b>."
-        
+            return (
+                f"Successfully set camera with url '{camera_url} "
+                f"to control status <b>'{status}'</b>."
+            )
     logger.info(f"Camera with url '{req_camera_url}' could not be found.")
     return f"ERROR<br/>Camera with url '{req_camera_url}' could not be found."
 
+
 @app.route('/control_status/<string:req_camera_url>')
 def view_current_camera_control_status(req_camera_url):
-    """ Endpoint for requesting the current control status (manual or automatic) for a camera.
+    """ Endpoint for requesting the current control status
+        (manual or automatic) for a camera.
         The desired camera is identified by the passed camera url.
     """
     # Get rid of http or https prefixes to ensure reliable comparability
-    sanitized_camera_url = str.replace(req_camera_url, 'http://', '').replace('https://', '')
+    sanitized_camera_url = str.replace(req_camera_url, 'http://', '')
+    sanitized_camera_url = str.replace(req_camera_url, 'https://', '')
+
     cameras = app.config["cameras"]
     for camera in cameras:
-        camera_url = str.replace(getattr(camera, 'url'), 'http://', '').replace('https://', '')
+        camera_url = str.replace(getattr(camera, 'url'), 'http://', '')
+        camera_url = str.replace(getattr(camera, 'url'), 'https://', '')
         if sanitized_camera_url == camera_url:
-            return f"STATUS<br/>The control status of the camera with url '{req_camera_url}' is <b>{getattr(camera, 'control')}</b>"
-        
+            return (
+                f"STATUS<br/>The control status of the camera "
+                f"with url '{req_camera_url}' is "
+                f"<b>{getattr(camera, 'control')}</b>"
+            )
     logger.info(f"Camera with url '{req_camera_url}' could not be found.")
     return f"ERROR</br>Camera with url '{req_camera_url}' could not be found."
+
 
 # expose camera control metrics
 @app.route('/metrics')
@@ -78,6 +93,7 @@ def metrics():
     # registry = CollectorRegistry()
     # multiprocess.MultiProcessCollector(registry)
     return Response(generate_latest(), content_type=CONTENT_TYPE_LATEST)
+
 
 def start_camera_control_server(cameras):
     """Start the flask server for managing the camera control

--- a/occameracontrol/camera_control_server.py
+++ b/occameracontrol/camera_control_server.py
@@ -1,0 +1,89 @@
+# Opencast Camera Control
+# Copyright 2024 Osnabrück University, virtUOS
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from importlib.metadata import requires
+
+from confygure import config_t
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+from flask import Flask, Response
+
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+@app.route('/control/<string:status>/<string:req_camera_url>')
+# @requires_auth
+def activate_camera(status, req_camera_url):
+    """ Endpoint for switching between manual and automatic camera control.
+        The desired camera is identified by the passed req_camera_url.
+    """
+    if status == "manual":
+        logger.info('Camera with URL "[%s]" will be controlled manually and ' +
+                            'therefore it\'s position won\'t be updated automatically.', req_camera_url)
+    elif status == "automatic":
+        logger.info('Camera with URL "[%s]" will switch to automatic controlling. The ' +
+                            'camera\'s position will be adjusted to the corresponding agent\'s status automatically.', req_camera_url)
+    else:
+        return f"ERROR<br/>Given status '{status}' is invalid. Please use 'manual' or 'automatic' instead."
+
+
+    # Get rid of http or https prefixes to ensure reliable comparability
+    sanitized_camera_url = str.replace(req_camera_url, 'http://', '').replace('https://', '')
+    cameras = app.config["cameras"]
+    for camera in cameras:
+        camera_url = str.replace(getattr(camera, 'url'), 'http://', '').replace('https://', '')
+        if sanitized_camera_url == camera_url:
+            setattr(camera, 'control', status)
+            # Resets the current position of the camera
+            setattr(camera, 'position', -1)
+            return f"SUCCESS<br/>Successfully set camera with url '{camera_url}' to control status <b>'{status}'</b>."
+        
+    logger.info(f"Camera with url '{req_camera_url}' could not be found.")
+    return f"ERROR<br/>Camera with url '{req_camera_url}' could not be found."
+
+@app.route('/control_status/<string:req_camera_url>')
+def view_current_camera_control_status(req_camera_url):
+    """ Endpoint for requesting the current control status (manual or automatic) for a camera.
+        The desired camera is identified by the passed camera url.
+    """
+    # Get rid of http or https prefixes to ensure reliable comparability
+    sanitized_camera_url = str.replace(req_camera_url, 'http://', '').replace('https://', '')
+    cameras = app.config["cameras"]
+    for camera in cameras:
+        camera_url = str.replace(getattr(camera, 'url'), 'http://', '').replace('https://', '')
+        if sanitized_camera_url == camera_url:
+            return f"STATUS<br/>The control status of the camera with url '{req_camera_url}' is <b>{getattr(camera, 'control')}</b>"
+        
+    logger.info(f"Camera with url '{req_camera_url}' could not be found.")
+    return f"ERROR</br>Camera with url '{req_camera_url}' could not be found."
+
+# expose camera control metrics
+@app.route('/metrics')
+# @requires_auth
+def metrics():
+    # registry = CollectorRegistry()
+    # multiprocess.MultiProcessCollector(registry)
+    return Response(generate_latest(), content_type=CONTENT_TYPE_LATEST)
+
+def start_camera_control_server(cameras):
+    """Start the flask server for managing the camera control
+    """
+    logger.info('Starting camera control server')
+    # start flask app
+    # ToDo get host and port from config, default 127.0.0.1:8000
+    app.config['cameras'] = cameras
+    app.run(host='127.0.0.1', port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ confygure >= 0.1.0
 prometheus-client >= 0.13.1
 python-dateutil
 requests
+flask >= 3.1.0


### PR DESCRIPTION
- Added a flag for switching the control status of a specific camera (see camera.py -> control).
- Added camera_control_server.py with two working endpoints: One for switching the control status, one for requesting the current status. Wrote log messages.
- Authentication and proper metrics are missing.
- Also, I haven't found a way to fetch the current, actual camera position yet.