### PR TITLE
Remove old metrics exporter

### DIFF
--- a/occameracontrol/__main__.py
+++ b/occameracontrol/__main__.py
@@ -25,7 +25,7 @@ from threading import Thread
 
 from occameracontrol.agent import Agent
 from occameracontrol.camera import Camera
-from occameracontrol.metrics import start_metrics_exporter, RequestErrorHandler
+from occameracontrol.metrics import RequestErrorHandler
 
 from occameracontrol.camera_control_server import start_camera_control_server
 
@@ -133,9 +133,6 @@ def main():
                                 args=(camera, reset_time))
         threads.append(control_thread)
         control_thread.start()
-
-    # Start delivering metrics
-    start_metrics_exporter()
 
     # Start camera control server
     auth = (config_rt(str, 'basic_auth', 'username'),

--- a/occameracontrol/metrics.py
+++ b/occameracontrol/metrics.py
@@ -118,26 +118,3 @@ def register_camera_expectation(camera: str, position: int):
     :param position: New camera position
     '''
     camera_position_expected.labels(camera).set(position)
-
-
-def start_metrics_exporter():
-    '''Start the web server for the metrics exporter endpoint if it is enabled
-    in the configuration.
-    '''
-    if not config_t(bool, 'metrics', 'enabled'):
-        return
-
-    supported_args = start_http_server.__code__.co_varnames
-    if 'certfile' in supported_args:
-        start_http_server(
-            port=config_t(int, 'metrics', 'port') or 8000,
-            addr=config_t(str, 'metrics', 'addr') or '127.0.0.1',
-            certfile=config_t(str, 'metrics', 'certfile'),
-            keyfile=config_t(str, 'metrics', 'keyfile'))
-    else:
-        if config_t(str, 'metrics', 'certfile'):
-            logger.warn('Old version of Prometheus client library does not yet'
-                        ' support TLS. Provided certificate will be ignored.')
-        start_http_server(
-            port=config_t(int, 'metrics', 'port') or 8000,
-            addr=config_t(str, 'metrics', 'addr') or '127.0.0.1')

--- a/occameracontrol/metrics.py
+++ b/occameracontrol/metrics.py
@@ -18,9 +18,7 @@ import logging
 import requests
 import time
 
-from confygure import config_t
 from prometheus_client import Counter, Gauge
-from prometheus_client import start_http_server
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This patch removes the redundant metric exporter, as metrics are now handled by the flask server.